### PR TITLE
Metadata: Allow org-style metadata headers

### DIFF
--- a/tests/Hakyll/Core/Provider/Metadata/Tests.hs
+++ b/tests/Hakyll/Core/Provider/Metadata/Tests.hs
@@ -19,7 +19,7 @@ import           TestSuite.Util
 --------------------------------------------------------------------------------
 tests :: Test
 tests = testGroup "Hakyll.Core.Provider.Metadata.Tests" $
-    fromAssertions "page" [testPage01, testPage02]
+    fromAssertions "page" [testPage01, testPage02, testPage03, testPage04]
 
 
 --------------------------------------------------------------------------------
@@ -44,6 +44,28 @@ testPage02 = testParse page
     descr =
         "A long description that would look better if it \
         \spanned multiple lines and was indented"
+
+
+--------------------------------------------------------------------------------
+testPage03 :: Assertion
+testPage03 = testParse page
+    ([("title", "Next: Org-mode")], "Yes, this is cow\n")
+    (unlines [ "#+title: Next: Org-mode"
+             , "Yes, this is cow"
+             ])
+
+
+--------------------------------------------------------------------------------
+testPage04 :: Assertion
+testPage04 = testParse page
+    ( [ ("tags", "org, emacs, test")
+      , ("date", "2014-05-23")
+      ], "\nTwenty five years ago today, the hacker Karl Koch died.\n")
+    (unlines [ "#+tags: org, emacs, test"
+             , "#+date: 2014-05-23"
+             , ""
+             , "Twenty five years ago today, the hacker Karl Koch died."
+             ])
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Org-style metadata definitions take the form of `#+KEY: value` and are
the standard way of defining metadata in Emacs Org-mode documents.  Such
as to avoid duplicate metadata definitions and a syntax unfamiliar to
org-mode users, this patch allowes the use of org-style metadata
definitions.  Every line at the beginning of a file which follows the
above pattern is treated as Hakyll metadata; keys are transformed to
lowercase.  The metadata-block is terminated by any other line.

As a consequence, if a user wants to define additional
metadata (e.g. `#+LINK` headers for Pandoc), she must separate those
metadata definitions from the topmost metadata block, e.g. using a blank
line.